### PR TITLE
Unify and pin pragma to 0.4.18

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.17;
+pragma solidity 0.4.18;
 
 // Note: For some reason Migrations.sol needs to be in the root or they run everytime
 

--- a/contracts/RocketUpgrade.sol
+++ b/contracts/RocketUpgrade.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.17;
+pragma solidity 0.4.18;
 
 import "./contract/Owned.sol";
 import "./RocketStorage.sol";

--- a/contracts/contract/Owned.sol
+++ b/contracts/contract/Owned.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.15;
+pragma solidity 0.4.18;
 
 contract Owned {
 

--- a/contracts/contract/StandardToken.sol
+++ b/contracts/contract/StandardToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.15;
+pragma solidity 0.4.18;
 
 contract Token {
     uint256 public totalSupply;

--- a/contracts/contract/casper/DummyCasper.sol
+++ b/contracts/contract/casper/DummyCasper.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.15;
+pragma solidity 0.4.18;
 
 import "../../contract/Owned.sol";
 

--- a/contracts/interface/CasperInterface.sol
+++ b/contracts/interface/CasperInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.17;
+pragma solidity 0.4.18;
 
 import "../contract/Owned.sol";
 

--- a/contracts/interface/TokenERC20Interface.sol
+++ b/contracts/interface/TokenERC20Interface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.17;
+pragma solidity 0.4.18;
 
 
 /// @title ERC20 Token Interface

--- a/contracts/lib/Arithmetic.sol
+++ b/contracts/lib/Arithmetic.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.17;
+pragma solidity 0.4.18;
 
 // Arithmetic library borrowed from Gnosis, thanks guys!
 

--- a/contracts/lib/SafeMath.sol
+++ b/contracts/lib/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.17;
+pragma solidity 0.4.18;
 
 
 /**


### PR DESCRIPTION
Following recommendation in this doc https://consensys.github.io/smart-contract-best-practices/recommendations/#lock-pragmas-to-specific-compiler-version