### PR TITLE
Update testrpc mentions and code to ganache-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rocket Pool - Your new Casper friendly Ethereum POS pool
 
-*NOTE: The current Alpha of Rocket Pool requires the latest [testrpc@v6.0.3](https://github.com/ethereumjs/testrpc) and [truffle@4](https://github.com/trufflesuite/truffle) to run locally.
+*NOTE: The current Alpha of Rocket Pool requires the latest [ganache-cli@v6.0.3](https://github.com/trufflesuite/ganache-cli) and [truffle@4](https://github.com/trufflesuite/truffle) to run locally.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/darcius/rocketpool/master/images/rocket-pool-logo.png?raw=true" alt="Rocket Pool - Next Generation Decentralised Ethereum Proof of Stake (POS) Pool"/>
@@ -20,11 +20,11 @@ The contracts are written in `solidity` and built with the Ethereum framework `t
   <img src="https://raw.githubusercontent.com/darcius/rocketpool/master/images/rocket-pool-casper-pos-test.png?raw=true" alt="Rocket Pool - Testing Ethereum Proof of Stake (POS) Pool"/>
 </p>
 
-Easiest way to see Rocket Pool alpha in action is to clone the repo, have testrpc running and the latest version of truffle installed. A quick and easy way to do this is to use the test script provided with the project:
+Easiest way to see Rocket Pool alpha in action is to clone the repo, have Ganache running and the latest version of truffle installed. A quick and easy way to do this is to use the test script provided with the project:
 ```bash
 $ npm install && npm test
 ```
-This will start testrpc (if not already started) with the current block gas limit and put Rocket Pool through its paces.
+This will start Ganache (if not already started) with the current block gas limit and put Rocket Pool through its paces.
 
 # Rocket Pool White Paper
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,37 +7,37 @@ set -o errexit
 trap cleanup EXIT
 
 cleanup() {
-  # Kill the testrpc instance that we started (if we started one and if it's still running).
-  if [ -n "$testrpc_pid" ] && ps -p $testrpc_pid > /dev/null; then
-    kill -9 $testrpc_pid
+  # Kill the Ganache instance that we started (if we started one and if it's still running).
+  if [ -n "$ganache_pid" ] && ps -p $ganache_pid > /dev/null; then
+    kill -9 $ganache_pid
   fi
 }
 
 if [ "$SOLIDITY_COVERAGE" = true ]; then
-  testrpc_port=8555
+  ganache_port=8555
 else
-  testrpc_port=8545
+  ganache_port=8545
 fi
 
-testrpc_running() {
-  nc -z localhost "$testrpc_port"
+ganache_running() {
+  nc -z localhost "$ganache_port"
 }
 
-start_testrpc() {
+start_ganache() {
   if [ "$SOLIDITY_COVERAGE" = true ]; then
-    node_modules/.bin/testrpc-sc --gasLimit 6725527 --port "$testrpc_port" > /dev/null &
+    node_modules/.bin/ganache-cli --gasLimit 6725527 --port "$ganache_port" > /dev/null &
   else
-    node_modules/.bin/testrpc --gasLimit 6725527 > /dev/null &
+    node_modules/.bin/ganache-cli --gasLimit 6725527 > /dev/null &
   fi
 
-  testrpc_pid=$!
+  ganache_pid=$!
 }
 
-if testrpc_running; then
-  echo "Using existing testrpc instance"
+if ganache_running; then
+  echo "Using existing Ganache instance"
 else
-  echo "Starting our own testrpc instance"
-  start_testrpc
+  echo "Starting our own Ganache instance"
+  start_ganache
 fi
 
 if [ "$SOLIDITY_COVERAGE" = true ]; then

--- a/test/rocketPool.js
+++ b/test/rocketPool.js
@@ -292,7 +292,7 @@ contract('RocketPool', accounts => {
       const miniPool = RocketPoolMini.at(poolAddress);
 
       // Get the pool status
-      const poolStatus = await miniPoolFirst.getStatus.call().valueOf();
+      const poolStatus = await miniPool.getStatus.call().valueOf();
       const poolBalance = web3.eth.getBalance(miniPool.address).valueOf();
 
       // Now just count the users to make sure this user wasn't added twice


### PR DESCRIPTION
I am not a fan of the rename because of how obscure it sounds vs `testrpc`. But we should still update all the references because over time the old name will fade into obscurity and make less sense. 

This also fixes the bash script to call the package installed via `npm install`.